### PR TITLE
Patch README.md - Homebrew locations

### DIFF
--- a/replicated-gcommands/README.md
+++ b/replicated-gcommands/README.md
@@ -19,8 +19,8 @@ GUSER='chriss'
 GPREFIX='chriss'
 
 # Setup gcloud commands
-source "/opt/homebrew/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/completion.zsh.inc"
-source "/opt/homebrew/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.zsh.inc"
+source "/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/completion.zsh.inc"
+source "/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.zsh.inc"
 ```
 
 Example Usage:


### PR DESCRIPTION
Upon setting up I've found that the gcloud command completion configs are no longer located in `/usr/local/...` Instead I've found that on my machine, Homebrew now sets this up in `/usr/local/Caskroom/...`