### PR TITLE
Add ip-forward flag

### DIFF
--- a/replicated-gcommands/replicated-gcommands.plugin.zsh
+++ b/replicated-gcommands/replicated-gcommands.plugin.zsh
@@ -39,7 +39,7 @@ gcreate() {
   (set -x; gcloud compute instances create ${instance_names[@]} \
     --labels owner="${GUSER}",email="${GUSER}__64__replicated__46__com" \
     --machine-type=n1-standard-8 \
-    --subnet=default --network-tier=PREMIUM --maintenance-policy=MIGRATE \
+    --subnet=default --network-tier=PREMIUM --maintenance-policy=MIGRATE --can-ip-forward \
     --service-account="${default_service_account}" \
     --scopes=https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append \
     --image="${image_name}" --image-project="${image_project}" \


### PR DESCRIPTION
This adds the flag to enable ip forwarding. When setting up a cluster that isn't using overlay networks this is necessary or the machine will block communication at the firewall. This fixes that issue for me test instances.