### PR TITLE
Readme: adding a way to use the replicated-gcommands without oh-my-zsh

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,6 +4,8 @@ This repository aggregates [custom plugins](https://github.com/ohmyzsh/ohmyzsh/#
 
 Each plugin should be prefaced with `replicated-` to avoid unintentional overrides of other plugins. Additionally plugins should be focused, split unrelated items into individual plugins to allow users to choose which ones they want to enable.
 
+## Oh My Zsh
+
 To install a plugin copy (or symlink!) the plugin to your custom folder `~/.oh-my-zsh/custom/plugins` and enable it in your `~/.zshrc` plugin list. Ex:
 
 ```zsh
@@ -11,3 +13,15 @@ plugins=(
         replicated-gcommands
         )
 ```
+
+## Manually Sourcing
+
+Alternatively if you don't want to use [Oh My Zsh](https://ohmyz.sh/) (eg. for performance reasons) you can just source in the ZSH commands (assuming a clone into `~/git/replicatedhq/oh-my-replicated`).
+
+Add to your `~/.zshrc`:
+
+```zsh
+source ~/git/replicatedhq/oh-my-replicated/replicated-gcommands/replicated-gcommands.plugin.zsh
+```
+
+Ensure you read the [`replicated-gcommands/README.md`](replicated-gcommands/README.md) for adding required environment variables also.


### PR DESCRIPTION
## Context

oh-my-zsh with most themes takes 160ms (ish) to spawn a shell, which is far from ideal. in comparison a fresh zsh install or powerlevel10k take more like 20~ms to spawn, and a clean/blank `bash` (5.x) is something like 1-10ms (ish)

this was tested with https://github.com/romkatv/powerlevel10k also, works fine

## Benchmarks

https://github.com/romkatv/zsh-bench

or try running `for i in $(seq 1 10); do /usr/bin/time $SHELL -i -c exit; done` in your local shell to see what results you get