### PR TITLE
add expires-on tag and optional flag to adjust [sc-68334]

### DIFF
--- a/replicated-gcommands/README.md
+++ b/replicated-gcommands/README.md
@@ -24,7 +24,7 @@ source "/opt/homebrew/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.zsh
 ```
 ### expires-on
 
-Instances are created by default with a lifetime of one day. If you would like to change this, provide the -d argument before the image and instance names with a valid macOS `date` duration string (e.g. `5d` for five days, `2w` for two weeks). If the instance must not be automatically reaped, provide `never` in the place of the duration string.
+Instances are created by default with a lifetime of one day. If you would like to change this, provide the -d argument before the image and instance names with a valid `date` duration string (implementation dependent; for macOS/BSD `date`, `1d` == one day, `1w` == one week, etc; for Linux/GNU `date`, `1 day` == one day, `1 week` == 1 week, etc). If the instance must not be automatically reaped, provide `never` in the place of the duration string.
 
 Example Usage:
 

--- a/replicated-gcommands/README.md
+++ b/replicated-gcommands/README.md
@@ -22,12 +22,15 @@ GPREFIX='chriss'
 source "/opt/homebrew/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/completion.zsh.inc"
 source "/opt/homebrew/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.zsh.inc"
 ```
+### expires-on
+
+Instances are created by default with a lifetime of one day. If you would like to change this, provide the -d argument before the image and instance names with a valid macOS `date` duration string (e.g. `5d` for five days, `2w` for two weeks). If the instance must not be automatically reaped, provide `never` in the place of the duration string.
 
 Example Usage:
 
 ```zsh
 ╭chris:~/.oh-my-zsh %
-╰➤ gcreate rhel-8-v20210817 chriss-test-rh
+╰➤ gcreate -d 1d rhel-8-v20210817 chriss-test-rh
 Configuration: qa-c
 +gcreate:15> echo chriss-test-rh
 +gcreate:15> gcloud compute instances create chriss-test-rh --labels 'owner=chriss' '--machine-type=n1-standard-4' '--subnet=default' '--network-tier=PREMIUM' '--maintenance-policy=MIGRATE' '--service-account=846065462912-compute@developer.gserviceaccount.com' '--scopes=https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append' '--image=rhel-8-v20210817' '--image-project=rhel-cloud' '--boot-disk-size=200GB' '--boot-disk-type=pd-standard' --no-shielded-secure-boot --shielded-vtpm --shielded-integrity-monitoring '--reservation-affinity=any'
@@ -44,3 +47,4 @@ Configuration: qa-c
 NAME            ZONE           MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP  EXTERNAL_IP   STATUS
 chriss-test-rh  us-central1-c  n1-standard-4               10.128.0.93  34.72.173.60  RUNNING
 ```
+

--- a/replicated-gcommands/replicated-gcommands.plugin.zsh
+++ b/replicated-gcommands/replicated-gcommands.plugin.zsh
@@ -16,6 +16,20 @@ glist() {
   gcloud compute instances list --filter="labels.owner:${GUSER}"
 }
 
+getdate() {
+  local duration="$1"
+  case $OSTYPE in 
+    darwin*)
+      [ -z "$duration" ] && duration="1d" || :
+      date "-v+${duration}" '+%Y-%m-%d'
+      ;;
+    linux*)
+      [ -z "$duration" ] && duration="1 day" || :
+      date -d "${duration}" '+%Y-%m-%d'
+      ;;
+  esac
+}
+
 gcreate() {
   genv
   local usage='Usage: gcreate [-d duration|never] <IMAGE> <INSTANCE_NAMES>'
@@ -23,12 +37,12 @@ gcreate() {
   while getopts ":d:" opt; do
     case $opt in
       d)
-        [ "$OPTARG" = "never" ] && expires="never" || expires="$(date "-v+${OPTARG}" '+%Y-%m-%d')"    
+        [ "$OPTARG" = "never" ] && expires="never" || expires="$(getdate "${OPTARG}")"    
         ;;
     esac
   done
   shift "$((OPTIND-1))"
-  [ -z "$expires" ] && expires="$(date -v+1d '+%Y-%m-%d')" || :
+  [ -z "$expires" ] && expires="$(getdate)" || :
   if [ "$#" -lt 2 ]; then echo "${usage}"; return 1; fi
   local image
   image="$(gcloud compute images list | grep -v arm | grep "$1" | awk 'NR == 1')"


### PR DESCRIPTION
* Add the `expires-on` tag to the instance creation command with a default of one day
* Add the `-d` flag to `gcreate` to specify a different duration.  
