### PR TITLE
enable nested virtualization support by default

### DIFF
--- a/replicated-gcommands/replicated-gcommands.plugin.zsh
+++ b/replicated-gcommands/replicated-gcommands.plugin.zsh
@@ -62,6 +62,8 @@ gcreate() {
   (set -x; gcloud compute instances create ${instance_names[@]} \
     --labels owner="${GUSER}",email="${GUSER}__64__replicated__46__com",expires-on="${expires}" \
     --machine-type=n1-standard-8 \
+    --enable-nested-virtualization \
+    --min-cpu-platform="Intel Haswell" \
     --subnet=default --network-tier=PREMIUM --maintenance-policy=MIGRATE --can-ip-forward \
     --service-account="${default_service_account}" \
     --scopes=https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append \


### PR DESCRIPTION
so we can run KVM/libvirt on our GCP VMs

before:

```
[root@nathans-okd-libvirt-centos8 snc]# grep "model name" /proc/cpuinfo  | head -n 1
model name	: Intel(R) Xeon(R) CPU @ 2.20GHz
[root@nathans-okd-libvirt-centos8 snc]# cat /sys/module/kvm_intel/parameters/nested
cat: /sys/module/kvm_intel/parameters/nested: No such file or directory
[root@nathans-okd-libvirt-centos8 snc]# grep vmx /proc/cpuinfo 
[root@nathans-okd-libvirt-centos8 snc]# lsmod | grep kvm_
[root@nathans-okd-libvirt-centos8 snc]# 
```

after:

```
[nathan@nathans-okd-build-centos8-kvm ~]$ grep "model name" /proc/cpuinfo  | head -n 1
model name	: Intel(R) Xeon(R) CPU @ 2.30GHz
[nathan@nathans-okd-build-centos8-kvm ~]$ grep vmx /proc/cpuinfo | head -n 1
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid tsc_known_freq pni pclmulqdq vmx ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm abm invpcid_single pti ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt arat md_clear arch_capabilities
[nathan@nathans-okd-build-centos8-kvm ~]$ cat /sys/module/kvm_intel/parameters/nested
1
[nathan@nathans-okd-build-centos8-kvm ~]$ lsmod | grep kvm_
kvm_intel             344064  0
kvm                   962560  1 kvm_intel
[nathan@nathans-okd-build-centos8-kvm ~]$
```